### PR TITLE
GDE-1161 Updates for Chef Client 13

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,5 +1,4 @@
-source "http://berks-api.grasshopper.com:26200"
-source "https://supermarket.getchef.com"
+source 'https://supermarket.chef.io'
 
 metadata
 

--- a/Berksfile
+++ b/Berksfile
@@ -3,5 +3,5 @@ source 'https://supermarket.chef.io'
 metadata
 
 group :testing do
-  cookbook "apt", "~> 2.4"
+  cookbook "apt", "~> 6.0"
 end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+[1.3.0 - 8/8/2017]
+  * [Bug] [Chef 13] - Node attribute for kernel machine fix
+
 [1.2.0 - 7/25/2017]
 
   * [Feature] [PAN-1766] (https://jira.grasshopper.com/browse/PAN-1766) : Change serf_service.erb to use -config-dir instead of -config-file

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,7 +11,7 @@ default["serf"]["agent"]["event_handlers"] = []
 default["serf"]["event_handlers"] = []
 
 default["serf"]["version"] = "0.7.0"
-default['serf']['arch'] = kernel['machine'] =~ /x86_64/ ? "amd64" : "386"
+default['serf']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? "amd64" : "386"
 
 default["serf"]["base_binary_url"] = "https://releases.hashicorp.com/serf/"
 default["serf"]["binary_url"] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,10 +5,11 @@ license          'The MIT License (MIT)'
 description      'Installs/Configures serf'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 
+chef_version '>= 12.1' if respond_to?(:chef_version)
+version          '1.3.0'
+
 %w{ ubuntu centos }.each do |os|
   supports os
 end
 
 depends 'logrotate'
-
-version          '1.2.0'


### PR DESCRIPTION
- Fixing how kernel machine attribute is accessed in attributes/default.rb